### PR TITLE
Mark repo ready when reloading from database

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/teaching/pottery/repo/Repo.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/teaching/pottery/repo/Repo.java
@@ -151,7 +151,15 @@ public class Repo {
         if (r.getRemote().equals(RepoInfo.REMOTE_UNSET) && !repoDirectory.exists()) {
           throw new RepoNotFoundException("Failed to find repository directory " + repoDirectory);
         }
-        return new Repo(r, config);
+        Repo repo = new Repo(r, config);
+        if (repo.repoInfo.getExpiryDate() != null) {
+          // Synchronize shouldn't be needed since we haven't given this to anyone yet, but being
+          // consistent
+          synchronized (repo.lockFields) {
+            repo.ready = true;
+          }
+        }
+        return repo;
       } else {
         throw new RepoNotFoundException(
             "Repository with ID " + repoId + " does not exist in database");

--- a/src/main/java/uk/ac/cam/cl/dtg/teaching/pottery/repo/Repo.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/teaching/pottery/repo/Repo.java
@@ -156,6 +156,8 @@ public class Repo {
           // Synchronize shouldn't be needed since we haven't given this to anyone yet, but being
           // consistent
           synchronized (repo.lockFields) {
+            // If the expiry date is set, then this repo was marked as ready previously, so set
+            // ready to true here
             repo.ready = true;
           }
         }

--- a/src/main/java/uk/ac/cam/cl/dtg/teaching/pottery/repo/RepoInfo.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/teaching/pottery/repo/RepoInfo.java
@@ -31,6 +31,8 @@ public class RepoInfo {
   private String repoId;
   private String taskId;
   private boolean usingTestingVersion;
+
+  @Nullable
   private Date expiryDate;
 
   private String variant;
@@ -72,6 +74,7 @@ public class RepoInfo {
     this.problemStatement = problemStatement;
   }
 
+  @Nullable
   public Date getExpiryDate() {
     return expiryDate;
   }


### PR DESCRIPTION
If the expiry date is set, the repo was marked as ready (it shouldn't ever not be set but seemed like it was worth checking.)