### PR TITLE
Add output limit restriction

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/teaching/pottery/containers/AttachListener.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/teaching/pottery/containers/AttachListener.java
@@ -24,10 +24,10 @@ class AttachListener implements WebSocketListener {
 
   private final StringBuilder output = new StringBuilder();
   private boolean closed = false;
-  private final int outputLimit;
+  private final int outputLimitChars;
 
-  AttachListener(int outputLimit) {
-    this.outputLimit = outputLimit;
+  AttachListener(int outputLimitChars) {
+    this.outputLimitChars = outputLimitChars;
   }
 
   public String getOutput() {
@@ -83,7 +83,7 @@ class AttachListener implements WebSocketListener {
   }
 
   boolean hasOverflowed() {
-    return output.length() > outputLimit;
+    return output.length() > outputLimitChars;
   }
 
   private void checkLength() {

--- a/src/main/java/uk/ac/cam/cl/dtg/teaching/pottery/containers/ContainerExecResponse.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/teaching/pottery/containers/ContainerExecResponse.java
@@ -28,7 +28,8 @@ public abstract class ContainerExecResponse {
     FAILED_OOM,
     FAILED_DISK,
     FAILED_TIMEOUT,
-    FAILED_UNKNOWN
+    FAILED_UNKNOWN,
+    FAILED_OUTPUT
   }
 
   public abstract Status status();

--- a/src/main/java/uk/ac/cam/cl/dtg/teaching/pottery/containers/DockerContainerImpl.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/teaching/pottery/containers/DockerContainerImpl.java
@@ -143,7 +143,7 @@ public class DockerContainerImpl implements ContainerBackend {
       try {
         docker.startContainer(containerId);
         AttachListener attachListener = new AttachListener(
-            executionConfig.containerRestrictions().getOutputLimitBytes());
+            executionConfig.containerRestrictions().getOutputLimitKilochars() * 1000);
 
         ScheduledFuture<Boolean> timeoutKiller =
             scheduleTimeoutKiller(

--- a/src/main/java/uk/ac/cam/cl/dtg/teaching/pottery/containers/DockerContainerImpl.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/teaching/pottery/containers/DockerContainerImpl.java
@@ -142,7 +142,8 @@ public class DockerContainerImpl implements ContainerBackend {
       runningContainers.add(containerId);
       try {
         docker.startContainer(containerId);
-        AttachListener attachListener = new AttachListener();
+        AttachListener attachListener = new AttachListener(
+            executionConfig.containerRestrictions().getOutputLimitBytes());
 
         ScheduledFuture<Boolean> timeoutKiller =
             scheduleTimeoutKiller(
@@ -211,6 +212,10 @@ public class DockerContainerImpl implements ContainerBackend {
 
           if (diskUsageKiller.isKilled()) {
             status = Status.FAILED_DISK;
+          }
+
+          if (attachListener.hasOverflowed()) {
+            status = Status.FAILED_OUTPUT;
           }
 
           try {

--- a/src/main/java/uk/ac/cam/cl/dtg/teaching/pottery/repo/Repo.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/teaching/pottery/repo/Repo.java
@@ -528,6 +528,11 @@ public class Repo {
                                     builder.addErrorMessage(
                                         "Output failed, execution time limit exceeded"));
                                 break;
+                              case FAILED_OUTPUT:
+                                updateSubmission(
+                                    builder.addErrorMessage(
+                                        "Output failed, output length limit exceeded"));
+                                break;
                               default:
                                 break;
                             }

--- a/src/main/java/uk/ac/cam/cl/dtg/teaching/pottery/task/ContainerRestrictions.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/teaching/pottery/task/ContainerRestrictions.java
@@ -22,29 +22,35 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class ContainerRestrictions {
 
-  private int timeoutSec;
+  private Integer timeoutSec;
 
-  private int diskWriteLimitMegabytes;
+  private Integer diskWriteLimitMegabytes;
 
-  private int ramLimitMegabytes;
+  private Integer ramLimitMegabytes;
 
-  private int outputLimitKilochars;
+  private Integer outputLimitKilochars;
 
-  private boolean networkDisabled;
+  private Boolean networkDisabled;
+
+  private final boolean fullySpecified;
 
   @JsonCreator
   public ContainerRestrictions(
-      @JsonProperty("timeoutSec") int timeoutSec,
-      @JsonProperty("diskWriteLimitMegabytes") int diskWriteLimitMegabytes,
-      @JsonProperty("ramLimitMegabytes") int ramLimitMegabytes,
-      @JsonProperty("outputLimitKilochars") int outputLimitKilochars,
-      @JsonProperty("networkDisabled") boolean networkDisabled) {
+      @JsonProperty("timeoutSec") Integer timeoutSec,
+      @JsonProperty("diskWriteLimitMegabytes") Integer diskWriteLimitMegabytes,
+      @JsonProperty("ramLimitMegabytes") Integer ramLimitMegabytes,
+      @JsonProperty("outputLimitKilochars") Integer outputLimitKilochars,
+      @JsonProperty("networkDisabled") Boolean networkDisabled) {
     super();
     this.timeoutSec = timeoutSec;
     this.diskWriteLimitMegabytes = diskWriteLimitMegabytes;
     this.ramLimitMegabytes = ramLimitMegabytes;
     this.outputLimitKilochars = outputLimitKilochars;
     this.networkDisabled = networkDisabled;
+    this.fullySpecified = this.timeoutSec != null && this.diskWriteLimitMegabytes !=  null
+        && this.ramLimitMegabytes != null && this.outputLimitKilochars != null
+        && this.networkDisabled != null;
+
   }
 
   public static final ContainerRestrictions DEFAULT_CANDIDATE_RESTRICTIONS =
@@ -70,5 +76,20 @@ public class ContainerRestrictions {
 
   public int getOutputLimitKilochars() {
     return outputLimitKilochars;
+  }
+
+  ContainerRestrictions withDefaultContainerRestriction(ContainerRestrictions defaultRestrictions) {
+    if (fullySpecified) {
+      return this;
+    }
+    return new ContainerRestrictions(
+        timeoutSec != null ? timeoutSec : defaultRestrictions.timeoutSec,
+        diskWriteLimitMegabytes != null ? diskWriteLimitMegabytes
+            : defaultRestrictions.diskWriteLimitMegabytes,
+        ramLimitMegabytes != null ? ramLimitMegabytes : defaultRestrictions.ramLimitMegabytes,
+        outputLimitKilochars != null ? outputLimitKilochars
+            : defaultRestrictions.outputLimitKilochars,
+        networkDisabled != null ? networkDisabled : defaultRestrictions.networkDisabled
+    );
   }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/teaching/pottery/task/ContainerRestrictions.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/teaching/pottery/task/ContainerRestrictions.java
@@ -28,6 +28,8 @@ public class ContainerRestrictions {
 
   private int ramLimitMegabytes;
 
+  private int outputLimitBytes;
+
   private boolean networkDisabled;
 
   @JsonCreator
@@ -35,18 +37,20 @@ public class ContainerRestrictions {
       @JsonProperty("timeoutSec") int timeoutSec,
       @JsonProperty("diskWriteLimitMegabytes") int diskWriteLimitMegabytes,
       @JsonProperty("ramLimitMegabytes") int ramLimitMegabytes,
+      @JsonProperty("outputLimitBytes") int outputLimitBytes,
       @JsonProperty("networkDisabled") boolean networkDisabled) {
     super();
     this.timeoutSec = timeoutSec;
     this.diskWriteLimitMegabytes = diskWriteLimitMegabytes;
     this.ramLimitMegabytes = ramLimitMegabytes;
+    this.outputLimitBytes = outputLimitBytes;
     this.networkDisabled = networkDisabled;
   }
 
   public static final ContainerRestrictions DEFAULT_CANDIDATE_RESTRICTIONS =
-      new ContainerRestrictions(60, 1, 200, true);
+      new ContainerRestrictions(60, 1, 200, 1000000, true);
   public static final ContainerRestrictions DEFAULT_AUTHOR_RESTRICTIONS =
-      new ContainerRestrictions(500, 50, 500, false);
+      new ContainerRestrictions(500, 50, 500, 50000000,false);
 
   public boolean isNetworkDisabled() {
     return networkDisabled;
@@ -62,5 +66,9 @@ public class ContainerRestrictions {
 
   public int getRamLimitMegabytes() {
     return ramLimitMegabytes;
+  }
+
+  public int getOutputLimitBytes() {
+    return outputLimitBytes;
   }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/teaching/pottery/task/ContainerRestrictions.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/teaching/pottery/task/ContainerRestrictions.java
@@ -28,7 +28,7 @@ public class ContainerRestrictions {
 
   private int ramLimitMegabytes;
 
-  private int outputLimitBytes;
+  private int outputLimitKilochars;
 
   private boolean networkDisabled;
 
@@ -37,20 +37,20 @@ public class ContainerRestrictions {
       @JsonProperty("timeoutSec") int timeoutSec,
       @JsonProperty("diskWriteLimitMegabytes") int diskWriteLimitMegabytes,
       @JsonProperty("ramLimitMegabytes") int ramLimitMegabytes,
-      @JsonProperty("outputLimitBytes") int outputLimitBytes,
+      @JsonProperty("outputLimitKilochars") int outputLimitKilochars,
       @JsonProperty("networkDisabled") boolean networkDisabled) {
     super();
     this.timeoutSec = timeoutSec;
     this.diskWriteLimitMegabytes = diskWriteLimitMegabytes;
     this.ramLimitMegabytes = ramLimitMegabytes;
-    this.outputLimitBytes = outputLimitBytes;
+    this.outputLimitKilochars = outputLimitKilochars;
     this.networkDisabled = networkDisabled;
   }
 
   public static final ContainerRestrictions DEFAULT_CANDIDATE_RESTRICTIONS =
-      new ContainerRestrictions(60, 1, 200, 1000000, true);
+      new ContainerRestrictions(60, 1, 200, 100, true);
   public static final ContainerRestrictions DEFAULT_AUTHOR_RESTRICTIONS =
-      new ContainerRestrictions(500, 50, 500, 50000000,false);
+      new ContainerRestrictions(500, 50, 500, 50000, false);
 
   public boolean isNetworkDisabled() {
     return networkDisabled;
@@ -68,7 +68,7 @@ public class ContainerRestrictions {
     return ramLimitMegabytes;
   }
 
-  public int getOutputLimitBytes() {
-    return outputLimitBytes;
+  public int getOutputLimitKilochars() {
+    return outputLimitKilochars;
   }
 }

--- a/src/main/java/uk/ac/cam/cl/dtg/teaching/pottery/task/Execution.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/teaching/pottery/task/Execution.java
@@ -68,10 +68,8 @@ public class Execution {
   }
 
   public Execution withDefaultContainerRestriction(ContainerRestrictions defaultRestrictions) {
-    if (restrictions == DEFAULT_RESTRICTIONS) {
-      return new Execution(image, program, defaultRestrictions);
-    }
-    return this;
+    return new Execution(image, program, restrictions == DEFAULT_RESTRICTIONS ? defaultRestrictions
+        : restrictions.withDefaultContainerRestriction(defaultRestrictions));
   }
 
   public Execution withProgram(String program) {

--- a/src/main/java/uk/ac/cam/cl/dtg/teaching/pottery/task/Execution.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/teaching/pottery/task/Execution.java
@@ -34,7 +34,7 @@ public class Execution {
 
   // This is just a marker value and is not expected to actually be used.
   private static final ContainerRestrictions DEFAULT_RESTRICTIONS =
-      new ContainerRestrictions(0, 0, 0, true);
+      new ContainerRestrictions(0, 0, 0, 0, true);
 
   @ApiModelProperty("Image that this execution should be run in.")
   private String image;


### PR DESCRIPTION
As discussed, it makes sense to be able to limit the amount of output from a task. Defaults of 50MB for authors and 1MB for candidates.

